### PR TITLE
Convert README to Markdown format; Code formatting, project metadata and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,38 @@
-###########
-Fritznagios
-###########
+# Fritznagios
 
+## About
 
-*****
-About
-*****
+Nagios/Icinga monitoring check program for FRITZ!Box based on the excellent
+[fritzconnection](https://github.com/kbr/fritzconnection) module.
 
-Nagios/Icinga monitoring check program based on the excellent `fritzconnection`_ module.
-
-
-*****
-Setup
-*****
-
-::
+## Setup
 
     python3 -m venv /opt/fritznagios
     /opt/fritznagios/bin/pip install git+https://github.com/cicerops/fritznagios
 
-
-*****
-Usage
-*****
-
-::
+## Usage
 
     fritznagios --help
 
+## Icinga 2
 
-********
-Icinga 2
-********
-
-For integrating the check program into Icinga 2, you can use the configuration files
-in the ``icinga2`` subdirectory. You can easily acquire the files using::
+For integrating the check program into Icinga 2, you can use the
+configuration files in the `icinga2` subdirectory. You can easily
+acquire the files using:
 
     wget https://raw.githubusercontent.com/cicerops/fritznagios/main/icinga2/fritznagios-command.conf
     wget https://raw.githubusercontent.com/cicerops/fritznagios/main/icinga2/fritznagios-services.conf
     wget https://raw.githubusercontent.com/cicerops/fritznagios/main/icinga2/fritznagios-host.conf
 
+## Development
 
-***********
-Development
-***********
-
-Acquire sources::
+Acquire sources:
 
     git clone https://github.com/cicerops/fritznagios
     cd fritznagios
 
-Install program in development mode::
+Install program in development mode:
 
     python3 -m venv .venv
     source .venv/bin/activate
     pip install --editable=.
-
-
-
-.. _fritzconnection: https://github.com/kbr/fritzconnection

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 ## About
 
-Nagios/Icinga monitoring check program for FRITZ!Box based on the excellent
-[fritzconnection](https://github.com/kbr/fritzconnection) module.
+Nagios/Icinga monitoring check program for FRITZ!Box devices based on the
+excellent [fritzconnection] module for maximum device coverage. It uses
+the TR-064 protocol over [UPnP].
+
+Icinga Exchange: https://exchange.icinga.com/tonke/fritznagios
+
+[fritzconnection]: https://github.com/kbr/fritzconnection
+[UPnP]: https://en.wikipedia.org/wiki/Universal_Plug_and_Play
 
 ## Setup
 

--- a/fritznagios.py
+++ b/fritznagios.py
@@ -2,19 +2,17 @@
 fritznagios.py
 
 Module for Nagios/Icinga2 to query the FritzBox API for available services and actions.
-CLI interface.
 
-This module depends on the FritzConnection package.
-https://github.com/kbr/fritzconnection
 License: MIT (https://opensource.org/licenses/MIT)
-Author: Klaus Bremer
-Edited by: Jan Hoffmann
-"""
+Author: Jan Hoffmann
+Source: https://github.com/cicerops/fritznagios
 
+This module depends on the FritzConnection module.
+Source: https://github.com/kbr/fritzconnection
+"""
 from fritzconnection.core.exceptions import FritzServiceError, FritzActionError
 from fritzconnection.lib.fritzstatus import FritzStatus
 from fritzconnection.core.fritzconnection import (
-    FritzConnection,
     FRITZ_IP_ADDRESS,
     FRITZ_TCP_PORT,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8; -*-
-
 import os
 
 from setuptools import setup
@@ -18,12 +16,12 @@ setup(
     url="https://github.com/cicerops/fritznagios",
     author="Jan Hoffmann",
     author_email="jan.hoffmann@bergamsee.de",
-    description="Monitoring sensor for Fritzboxes",
+    description="Nagios/Icinga monitoring check program for FRITZ!Box devices",
     long_description=long_description,
     long_description_content_type="text/markdown",
     platforms=["any"],
     license="MIT",
-    keywords="AVM, FRITZ!Box, fritzbox, fritz, Nagios, Icinga",
+    keywords="FRITZ!Box, AVM, fritzbox, fritz, Nagios, Icinga, monitoring, TR-064, UPnP",
     py_modules=["fritznagios"],
     entry_points={"console_scripts": ["fritznagios = fritznagios:main"]},
     python_requires=">=3.4",
@@ -50,6 +48,9 @@ setup(
         "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Archiving",
+        "Topic :: System :: Logging",
+        "Topic :: System :: Monitoring",
+        "Topic :: System :: Systems Administration",
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(path):
         return f.read()
 
 
-long_description = read("README.rst")
+long_description = read("README.md")
 
 setup(
     name="fritznagios",
@@ -20,7 +20,7 @@ setup(
     author_email="jan.hoffmann@bergamsee.de",
     description="Monitoring sensor for Fritzboxes",
     long_description=long_description,
-    long_description_content_type="text/x-rst",
+    long_description_content_type="text/markdown",
     platforms=["any"],
     license="MIT",
     keywords="AVM, FRITZ!Box, fritzbox, fritz, Nagios, Icinga",


### PR DESCRIPTION
Hi,

those are just some documentation updates and a bit beyond.

- 39df1d7375: Convert README to Markdown format intends to improve display on https://exchange.icinga.com/tonke/fritznagios. The conversion was done with [pandoc], like `pandoc README.rst -o README.md`.
- 4b64492390: Some maintenance updates to project metadata and documentation.

With kind regards,
Andreas.

[pandoc]: https://pandoc.org/